### PR TITLE
Moved Index.countmembers() into _QuadTree._countmembers()

### DIFF
--- a/pyqtree.py
+++ b/pyqtree.py
@@ -77,6 +77,7 @@ Karim Bahgat (2015)
 __version__ = "0.24"
 
 #PYTHON VERSION CHECK
+import pdb
 import sys
 PYTHON3 = int(sys.version[0]) == 3
 if PYTHON3:
@@ -225,6 +226,20 @@ class _QuadTree:
         for node in nodes:
             self._insert_into_children(node.item, node.rect)
 
+    def _countmembers(self):
+        """
+        Returns:
+        
+        - A count of the total number of members/items/nodes inserted
+        into this quadtree and all of its child trees.
+        """
+        size = 0
+        for child in self.children:
+            size += child._countmembers()
+        size += len(self.nodes)
+        return size
+
+
 #USER CLASSES AND FUNCTIONS
             
 class Index(_QuadTree):
@@ -290,11 +305,7 @@ class Index(_QuadTree):
         - A count of the total number of members/items/nodes inserted into
             this quadtree and all of its child trees.
         """
-        size = 0
-        for child in self.children:
-            size += child.countmembers()
-        size += len(self.nodes)
-        return size
+        return self._countmembers()
 
 
 

--- a/pyqtree.py
+++ b/pyqtree.py
@@ -77,7 +77,6 @@ Karim Bahgat (2015)
 __version__ = "0.24"
 
 #PYTHON VERSION CHECK
-import pdb
 import sys
 PYTHON3 = int(sys.version[0]) == 3
 if PYTHON3:

--- a/testing.py
+++ b/testing.py
@@ -15,6 +15,7 @@ items = [Item(random.randrange(5,95),random.randrange(5,95)) for _ in range(1000
 spindex = pyqtree.Index(bbox=[-11,-33,100,100])
 for item in items:
     spindex.insert(item, item.bbox)
+print("{0} members in this index.".format(spindex.countmembers()))
 
 #test intersection
 print("testing hit")
@@ -35,5 +36,5 @@ for item in items:
 # check result
 members = spindex.countmembers()
 assert(members == 4)
-print "{0} nodes in this Index.".format(members)
+print("{0} nodes in this Index.".format(members))
 

--- a/testing.py
+++ b/testing.py
@@ -22,3 +22,18 @@ testitem = (51,51,86,86)
 t = time.time()
 matches = spindex.intersect(testitem)
 print(time.time()-t, " seconds")
+
+#test countmembers()
+# trivial list of items
+items = [Item(0.5, 0.5), Item(-0.5, 0.5), Item(-0.5, -0.5), Item(0.5, -0.5)]
+
+# populate: maxindex=3, so we must split
+spindex = pyqtree.Index(bbox=[-1, -1, 1, 1], maxitems=3)
+for item in items:
+    spindex.insert(item, item.bbox)
+
+# check result
+members = spindex.countmembers()
+assert(members == 4)
+print "{0} nodes in this Index.".format(members)
+


### PR DESCRIPTION
Looks as if this was accidentally moved into Index at some point in the past. Tested in Python 2.7.